### PR TITLE
Update EventEmitter import

### DIFF
--- a/src/KaxTaskEventEmitter.ts
+++ b/src/KaxTaskEventEmitter.ts
@@ -1,3 +1,3 @@
-import EventEmitter from 'events'
+import { EventEmitter } from 'events'
 
 export class KaxTaskEventEmitter extends EventEmitter {}


### PR DESCRIPTION
This will prevent the following error with `@types/node` version `13.5.0` or later:

```
error TS2507: Type 'typeof EventEmitter' is not a constructor function type.

3 export declare class KaxTaskEventEmitter extends EventEmitter {
                                                   ~~~~~~~~~~~~


Found 1 error.
```

Without this, it would also be a issue for any project using `kax` (preventing them from updating `types/node` to `13.5.0` or higher, without an explicit tsconfig change to exclude the problematic file).