### PR TITLE
Update gitignore and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,7 @@
-# OSX
 .DS_Store
-
-# NODE
 node_modules/
-*/node_modules
-
-# YARN
 yarn-error.log
-
-# TESTS
-*/tmp
-
-# DISTRIB
-dist
+tmp/
+dist/
+.idea/
+*.iml

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-src
-sample
-test
-.vscode

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.2",
   "description": "A simple logger with spinners",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
Small change with a big impact on the packed archive size!

Update and simplify `.gitignore`, add `files` array to `package.json`. Remove `.npmignore` (no longer necessary).
This explicitly _includes_ the `dist` folder, and, most importantly, now **excludes** the `media/` folder (which was previously put in the archive).

Unpacked tarball size went from 3.4 MB to 41 kB! (similar size reduction to the packed file as well, since the .gif doesn't compress well).

```
$ npm view kax@2.0.2 dist.unpackedSize
3391156

$ npm pack --dry-run
...
npm notice unpacked size: 40.9 kB
...
```

