### PR TITLE
Default to simple renderer in limited termcap envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ It will render as follow
 
 `kax` comes with two different renderers
 
-- `KaxSimpleRenderer`  
-  A simple renderer that do not make use of spinners and subtasks indentation. It can be useful for environments that do not play well with spinners or do not need them (for example CI envs).
+- `KaxSimpleRenderer`\
+Does not use spinners, colors, or subtask indentation.
 
-- `KaxAdvancedRenderer`  
-  The default `kax` renderer. It uses spinners, colors, and subtasks indentation.
+- `KaxAdvancedRenderer`\
+Uses spinners, colors, and subtask indentation.
 
 ## Initialization
 
@@ -51,7 +51,10 @@ It will render as follow
 import kax from 'kax'
 ```
 
-This default singleton instance comes with the default renderer `KaxAdvancedRender` attached to it, with a default configuration.
+This default singleton instance comes with a default renderer and configuration attached to it.
+
+If the `CI` environment variable is set, or `TERM=dumb`, the default renderer
+is `KaxSimpleRenderer`, otherwise it is `KaxAdvancedRenderer`.
 
 If you need to customize the renderer with your own configuration, or need to switch to a `KaxSimpleRenderer` instead, you can instantiate a renderer with a custom configuration and attached it to the kax instance.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import { Kax } from './Kax'
-import { KaxAdvancedRenderer } from './renderers'
+import { KaxAdvancedRenderer, KaxSimpleRenderer } from './renderers'
 
-export default new Kax(new KaxAdvancedRenderer())
+const getDefaultRenderer = () => {
+  return process.env.TERM === 'dumb' || process.env.CI
+    ? new KaxSimpleRenderer()
+    : new KaxAdvancedRenderer()
+}
+export default new Kax(getDefaultRenderer())
+export { getDefaultRenderer }
 
 export * from './renderers'
 export * from './types'

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,39 @@
 import 'mocha'
+import { KaxAdvancedRenderer, KaxSimpleRenderer } from '../src/renderers'
+import { getDefaultRenderer } from '../src'
 
-describe('Noop', () => {
-  it('should work', () => {})
+const { assert } = require('chai')
+
+describe('Default renderer based on environment', () => {
+  let envCi, envTerm
+  before(function() {
+    envCi = process.env.CI
+    envTerm = process.env.TERM
+  })
+  after(function() {
+    delete process.env.CI
+    delete process.env.TERM
+    if (envCi) process.env.CI = envCi
+    if (envTerm) process.env.TERM = envTerm
+  })
+  beforeEach(() => {
+    delete process.env.CI
+    delete process.env.TERM
+  })
+
+  it('should use KaxAdvancedRenderer by default', () => {
+    assert.instanceOf(getDefaultRenderer(), KaxAdvancedRenderer)
+  })
+  it('should use KaxSimpleRenderer when CI is set', () => {
+    process.env.CI = 'true'
+    assert.instanceOf(getDefaultRenderer(), KaxSimpleRenderer)
+  })
+  it('should use KaxSimpleRenderer when TERM is "dumb"', () => {
+    process.env.TERM = 'dumb'
+    assert.instanceOf(getDefaultRenderer(), KaxSimpleRenderer)
+  })
+  it('should use KaxAdvancedRenderer when TERM is not "dumb"', () => {
+    process.env.TERM = 'xterm-color'
+    assert.instanceOf(getDefaultRenderer(), KaxAdvancedRenderer)
+  })
 })


### PR DESCRIPTION
A small improvement to the default Kax instance, now automatically selecting the default renderer based on the environment.

There is _no_ change in behavior for a regular user.

If the I/O buffer has limited capabilities (e.g. in a CI environment), it will select `KaxSimpleRenderer` instead of `KaxAdvancedRenderer` by default. This is determined by the `CI` environment variable, or if `TERM=dumb`. Also added a few tests.