### PR TITLE
Update tsconfig.json

### DIFF
--- a/src/KaxTimer.ts
+++ b/src/KaxTimer.ts
@@ -1,9 +1,9 @@
 export class KaxTimer {
   private _startEpoc: number
   private _curEpoc: number
-  private _cursSecs: number = 0
-  private _curMins: number = 0
-  private _interval: NodeJS.Timer
+  private _cursSecs = 0
+  private _curMins = 0
+  private _interval: NodeJS.Timeout | null = null
 
   public constructor() {
     this._startEpoc = Date.now()
@@ -21,7 +21,9 @@ export class KaxTimer {
   }
 
   public stop() {
-    clearInterval(this._interval)
+    if (this._interval) {
+      clearInterval(this._interval)
+    }
     return this
   }
 

--- a/src/renderers/KaxSimpleRenderer.ts
+++ b/src/renderers/KaxSimpleRenderer.ts
@@ -70,8 +70,7 @@ export class KaxSimpleRenderer implements KaxRenderer {
   }
 
   public renderTask<T>(msg: string, task: KaxTask<T>) {
-    let pendingTaskMsg = `[ ${msg} (Started) ]`
-    this.renderLine(pendingTaskMsg, process.stdout, {
+    this.renderLine(`[ ${msg} (Started) ]`, process.stdout, {
       color: this._opts.colorScheme && this._opts.colorScheme.task,
     })
     task.emitter.on(KaxTask.Success, (successMsg?: string) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "allowJs": false,
-    "esModuleInterop": true,
-    "lib": ["es2017"],
+    "target": "es2018",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "lib": ["es2018"],
+    "declaration": true,
     "sourceMap": true,
-    "preserveSymlinks": true,
-    "strictNullChecks": true,
-    "rootDir": "./src",
     "outDir": "dist",
-    "declaration": true
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
-  "include": ["**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts", "test", "dist", "sample"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Since we now require Node >= 10 (#13), the project can make use a slightly more optimized TypeScript compilation (using es2018 target and lib). This also removes a couple of configuration options which were either the default or not applicable to the repo.

With one minimal code change in `KaxTimer`, it's possible to enable **all strict TypeScript checks** (_except_ `noImplicitAny`, which would require significant code changes).