### PR TITLE
Use separate version/publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         node: ['14', '16', '18']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: yarn --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,16 @@
 name: publish
 on:
-  push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  release:
+    types: [published]
 jobs:
   publish:
-    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn --frozen-lockfile
-      - run: yarn test
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,41 @@
+name: version
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Release Type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Set Git user
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - run: npm version ${{ github.event.inputs.type }}
+      - run: git push --follow-tags
+      - run: echo "VERSION=$(npm -s run env echo '$npm_package_version')" >> $GITHUB_ENV
+      - name: Create Release Notes
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.request(`POST /repos/${{ github.repository }}/releases`, {
+              draft: true,
+              generate_release_notes: true,
+              name: "${{ env.VERSION }}",
+              tag_name: "v${{ env.VERSION }}"
+            });


### PR DESCRIPTION
Creating a new version can now be done entirely on GitHub's UI, using GitHub Actions.

The `version` workflow handles updating the repo, while the `publish` workflow runs when a new release on [Releases](https://github.com/electrode-io/kax/releases) is created. A _draft_ release with auto populated release notes is created when running the version workflow.