### PR TITLE
Revert "Remove unused generic type T from KaxTask"

### DIFF
--- a/src/Kax.ts
+++ b/src/Kax.ts
@@ -24,8 +24,8 @@ export class Kax {
     this._renderer.renderRaw(msg);
   }
 
-  public task(msg: string): KaxTask {
-    const task = new KaxTask();
+  public task<T>(msg: string): KaxTask<T> {
+    const task = new KaxTask<T>();
     this._renderer.renderTask(msg, task);
     return task;
   }

--- a/src/KaxTask.ts
+++ b/src/KaxTask.ts
@@ -1,7 +1,8 @@
 import { KaxTaskEventEmitter } from './KaxTaskEventEmitter';
 import { KaxTimer } from './KaxTimer';
 
-export class KaxTask {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export class KaxTask<T> {
   public readonly emitter: KaxTaskEventEmitter = new KaxTaskEventEmitter();
 
   public static readonly Success: string = 'success';
@@ -14,6 +15,7 @@ export class KaxTask {
 
   private _kaxTimer: KaxTimer = new KaxTimer().start();
 
+  // eslint-disable-next-line @typescript-eslint/no-shadow
   public async run<T>(
     task: Promise<T>,
     {

--- a/src/renderers/KaxAdvancedRenderer.ts
+++ b/src/renderers/KaxAdvancedRenderer.ts
@@ -81,7 +81,7 @@ export class KaxAdvancedRenderer implements KaxRenderer {
     this.render();
   }
 
-  public renderTask(msg: string, task: KaxTask) {
+  public renderTask<T>(msg: string, task: KaxTask<T>) {
     const linesIdx =
       this._lines.push(
         this.formatLineInternal(msg, {

--- a/src/renderers/KaxSimpleRenderer.ts
+++ b/src/renderers/KaxSimpleRenderer.ts
@@ -71,7 +71,7 @@ export class KaxSimpleRenderer implements KaxRenderer {
     process.stdout.write(`${msg}${os.EOL}`);
   }
 
-  public renderTask(msg: string, task: KaxTask) {
+  public renderTask<T>(msg: string, task: KaxTask<T>) {
     this.renderLine(`[ ${msg} (Started) ]`, process.stdout, {
       color: this._opts.colorScheme && this._opts.colorScheme.task,
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,6 @@ export interface KaxRenderer {
   renderWarning(msg: string);
   renderInfo(msg: string);
   renderError(msg: string);
-  renderTask(msg: string, task: KaxTask);
+  renderTask<T>(msg: string, task: KaxTask<T>);
   renderRaw(msg: string);
 }


### PR DESCRIPTION
This reverts commit d32da4aadc80b5a350811ebc3a2df0f865289c54.

It turns out removing the unused generic parameter was an API breaking change that should have been released with a major version update, but it was shipped in `3.1.0`. Revert the commit in order to immediately release `3.1.1`.

Removal of the parameter will be done in a future release `4.0.0`.